### PR TITLE
CI Debugging (Daniel) - Fail Black Format Check

### DIFF
--- a/ci_lab/src/counter.py
+++ b/ci_lab/src/counter.py
@@ -12,7 +12,7 @@ app = Flask(__name__)
 COUNTERS = {}
 
 # Intentional Black violation for Phase 3 debugging PR
-_dummy = {"a":1,"b":2}                                                                                                    
+_dummy = {"a": 1, "b": 2}
 
 
 def is_valid_counter_name(name):

--- a/ci_lab/src/counter.py
+++ b/ci_lab/src/counter.py
@@ -11,6 +11,9 @@ app = Flask(__name__)
 # Dictionary to store counters
 COUNTERS = {}
 
+# Intentional Black violation for Phase 3 debugging PR
+_dummy = {"a":1,"b":2}                                                                                                    
+
 
 def is_valid_counter_name(name):
     """Validate counter name to ensure it contains only alphanumeric characters"""


### PR DESCRIPTION
This PR satisfies the Phase 3 Debugging PR requirement by introducing a controlled CI failure, diagnosing it from the Actions logs, and then fixing it.

### Intentional failure: 
A Black formatting violation was added in ci_lab/src/counter.py: a dict literal without spaces after colons (`{"a":1,"b":2}`) and a line with trailing whitespace. The existing “Run Black (check only)” step in the workflow fails on these style issues.

### Root cause: 
Black requires spaces after colons in dict literals (`{"a": 1, "b": 2}`) and disallows trailing whitespace. The added code violated both rules, so `black --check src tests` failed.

### Fix: 
The intentional violation (the comment and `_dummy` line) was formatted so the file again passes `black --check`.
Re-run: After the fix was pushed, the workflow was re-run and all steps, including Black, passed.

### CI evidence:
With the error introduced:
![Screenshot 2026-02-16 at 11 13 23 PM](https://github.com/user-attachments/assets/6fcbda3a-79f3-485d-8f8e-00659f52a387)


With black formatted:
![Screenshot 2026-02-16 at 11 13 56 PM](https://github.com/user-attachments/assets/3e627c1e-63ef-4c8a-ae83-20131f439c3c)



